### PR TITLE
Add two parameters for extracting metadata and readme files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ output_dir/
 defoe/*
 env_*
 inspect4py.egg-info/*
+test/test_files/hellogitworld

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ Options:
   -ast, -—abstract_syntax_tree    generates abstract syntax tree in json format.
   -sc, --source_code              generates source code of each ast node.
   -ld, --license_detection        detects the license of the target repository.
+  -rm, --readme                   extract all readme files in the target repository.
+  -md, --metadata                 extract metadata of the target repository using
+                                  Github API.
   --help                          Show this message and exit.
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,5 +47,8 @@ Options:
   -ast, -—abstract_syntax_tree    generates abstract syntax tree in json format.
   -sc, --source_code              generates source code of each ast node.
   -ld, --license_detection        detects the license of the target repository.
+  -rm, --readme                   extract all readme files in the target repository.
+  -md, --metadata                 extract metadata of the target repository using
+                                  Github API.
   --help                          Show this message and exit.
 ```

--- a/inspect4py/cli.py
+++ b/inspect4py/cli.py
@@ -1254,7 +1254,8 @@ def main(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, r
                 if ".py" in f and not f.endswith(".pyc"):
                     try:
                         path = os.path.join(subdir, f)
-                        out_dir = output_dir + "/" + os.path.basename(subdir) # TODO: This could create path like /parent//child
+                        relative_path = Path(subdir).relative_to(Path(input_path).parent)
+                        out_dir = str(Path(output_dir) / relative_path)
                         cf_dir, json_dir = create_output_dirs(out_dir, control_flow)
                         code_info = CodeInspection(path, cf_dir, json_dir, fig, control_flow, abstract_syntax_tree, source_code)
                         if code_info.fileJson:

--- a/inspect4py/cli.py
+++ b/inspect4py/cli.py
@@ -1200,8 +1200,13 @@ def create_output_dirs(output_dir, control_flow):
               help="generates the source code of each ast node.")
 @click.option('-ld', '--license_detection', type=bool, is_flag=True,
               help="detects the license of the target repository.")
+@click.option('-rm', '--readme', type=bool, is_flag=True,
+              help="extract all readme files in the target repository.")
+@click.option('-md', '--metadata', type=bool, is_flag=True, 
+              help="extract metadata of the target repository using Github API. (requires repository to have the .git folder)")
 def main(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements, html_output, call_list,
-         control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection):
+         control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection, readme,
+         metadata):
     if (not os.path.isfile(input_path)) and (not os.path.isdir(input_path)):
         print('The file or directory specified does not exist')
         sys.exit()
@@ -1305,6 +1310,10 @@ def main(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, r
                 dir_info["detected_license"] = [{k: f"{v:.1%}"} for k, v in rank_list]
             except:
                 pass
+        if readme:
+            dir_info["readme_files"] = extract_readme(input_path)
+        if metadata:
+            dir_info["metadata"] = get_github_metadata(input_path)
         json_file = output_dir + "/directory_info.json"
         pruned_json = prune_json(dir_info)
         with open(json_file, 'w') as outfile:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ setuptools==54.2.0
 json2html
 configparser
 bigcode_astgen
+GitPython

--- a/test/test_files/test_readme/README.md
+++ b/test/test_files/test_readme/README.md
@@ -1,0 +1,1 @@
+README.md in root dir

--- a/test/test_files/test_readme/subdir/README.txt
+++ b/test/test_files/test_readme/subdir/README.txt
@@ -1,0 +1,1 @@
+README.txt in subdir

--- a/test/test_files/test_readme/subdir/subsubdir/README.rst
+++ b/test/test_files/test_readme/subdir/subsubdir/README.rst
@@ -1,0 +1,1 @@
+README.rst in subsubdir

--- a/test/test_inspect4py.py
+++ b/test/test_inspect4py.py
@@ -1,5 +1,6 @@
 import unittest
 import shutil
+import requests
 from inspect4py.cli import *
 from inspect4py import cli, utils
 
@@ -268,8 +269,11 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = False
+        readme = False
+        metadata = False
         dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)
         current_type = dir_info['software_type']
         shutil.rmtree(output_dir)
         assert current_type[0]["type"] == "service"
@@ -288,8 +292,11 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = False
+        readme = False
+        metadata = False
         dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)        
         current_type = dir_info['software_type']
         shutil.rmtree(output_dir)
         assert current_type[0]["type"] == "package"
@@ -308,8 +315,11 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = False
+        readme = False
+        metadata = False
         dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)
         current_type = dir_info['software_type']
         shutil.rmtree(output_dir)
         assert current_type[0]["type"] == "library"
@@ -329,8 +339,11 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = False
+        readme = False
+        metadata = False
         dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree,
+                                    source_code, license_detection, readme, metadata)
         imports = dir_info['software_invocation']
         shutil.rmtree(output_dir)
         assert len(imports[0]["imports"]) == 2
@@ -351,8 +364,11 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = False
+        readme = False
+        metadata = False
         dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree,
+                                    source_code, license_detection, readme, metadata)
         current_type = dir_info['software_type']
         shutil.rmtree(output_dir)
         assert current_type[0]["type"] == "script"
@@ -531,19 +547,93 @@ class Test(unittest.TestCase):
         abstract_syntax_tree = False
         source_code = False
         license_detection = True
+        readme = False
+        metadata = False
 
         expected_liceses = ['Apache-2.0', 'LGPL-3.0', 'MIT']
         first_rank_licenses = []
         for input_path in input_paths:
             dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection)
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)
             first_rank_licenses.append(next(iter(dir_info["detected_license"][0])))
             shutil.rmtree(output_dir)
         
         assert first_rank_licenses == expected_liceses
 
+
+    def test_readme(self):
+        input_path = "./test_files/test_readme"
+        output_dir = "./output_dir"
+        fig = False
+        ignore_dir_pattern = [".", "__pycache__"]
+        ignore_file_pattern = [".", "__pycache__"]
+        requirements = False
+        call_list = False
+        control_flow = False
+        directory_tree = False
+        software_invocation = False
+        abstract_syntax_tree = False
+        source_code = False
+        license_detection = False
+        readme = True
+        metadata = False
+
+        dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)
+
+        root_dir = Path(input_path)
+        expected_readme_files = {
+            f"{root_dir}/README.md": "README.md in root dir\n",
+            f"{root_dir}/subdir/README.txt": "README.txt in subdir\n",
+            f"{root_dir}/subdir/subsubdir/README.rst": "README.rst in subsubdir\n"
+        }
+        actual_readme_files = dir_info["readme_files"]
+        print(actual_readme_files)
+        assert expected_readme_files == actual_readme_files        
+
+
+    def test_metadata(self):
+        """ 
+        Need to execute under test/test_files/: 
+        `git clone https://github.com/githubtraining/hellogitworld.git`
+        to pass this test, as getting metadata requires the local repository
+        to have a .git folder.
+        """
+        input_path = "./test_files/hellogitworld"
+        output_dir = "./output_dir"
+        fig = False
+        ignore_dir_pattern = [".", "__pycache__"]
+        ignore_file_pattern = [".", "__pycache__"]
+        requirements = False
+        call_list = False
+        control_flow = False
+        directory_tree = False
+        software_invocation = False
+        abstract_syntax_tree = False
+        source_code = False
+        license_detection = False
+        readme = False
+        metadata = True
+
+        dir_info = invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
+                                    call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, 
+                                    source_code, license_detection, readme, metadata)
+        try:
+            response = requests.get("https://api.github.com/repos/githubtraining/hellogitworld")
+            expected_metadata = response.json()
+        except requests.RequestException as e:
+            print(f"Error sending requests to Github API: {e}")
+            raise e
+
+        actual_metadata = dir_info["metadata"]
+        assert expected_metadata == actual_metadata        
+
+
 def invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_file_pattern, requirements,
-                     call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree, source_code, license_detection):
+                     call_list, control_flow, directory_tree, software_invocation, abstract_syntax_tree,
+                     source_code, license_detection, readme, metadata):
     dir_info = {}
     # retrieve readme text at the root level (if any)
     readme = ""
@@ -612,6 +702,10 @@ def invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_fil
             licenses_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../inspect4py/licenses")
             rank_list = detect_license(input_path, licenses_path)
             dir_info["detected_license"] = [{k: f"{v:.1%}"} for k, v in rank_list]
+    if readme:
+        dir_info["readme_files"] = extract_readme(input_path)
+    if metadata:
+        dir_info["metadata"] = get_github_metadata(input_path)
     return dir_info
 
 

--- a/test/test_inspect4py.py
+++ b/test/test_inspect4py.py
@@ -653,7 +653,8 @@ def invoke_inspector(input_path, fig, output_dir, ignore_dir_pattern, ignore_fil
             if ".py" in f and not f.endswith(".pyc"):
                 try:
                     path = os.path.join(subdir, f)
-                    out_dir = output_dir + "/" + os.path.basename(subdir)
+                    relative_path = Path(subdir).relative_to(Path(input_path).parent)
+                    out_dir = str(Path(output_dir) / relative_path)
                     cf_dir, json_dir = create_output_dirs(out_dir, control_flow)
                     code_info = CodeInspection(path, cf_dir, json_dir, fig, control_flow, abstract_syntax_tree, source_code)
                     if out_dir not in dir_info:


### PR DESCRIPTION
In this pull request two new parameters are added. This includes:
- `-rm --readme` to recursively extract all README files in the target repository.
- `-md --metadata` to get remote url from the local repository's `.git` folder and access Github API (https://api.github.com/repos/{owner}/{repo}) to get all metadata of the remote repository.

Tests and test files are also added for them, however, since `git` command ignore `.git` folder, I cannot push another git repository here. Therefore, test files for `-md --metadata` parameter need to be manually cloned in order to pass this test:
https://github.com/zl81/inspect4py/blob/9b4a27bda4feee5ba322094229a70af374ee0a80/test/test_inspect4py.py#L597-L632

This pull request also resolves #365, by using relative path to store json files in the output directory.