### PR TITLE
Extend license detection to include extracted license text 

### DIFF
--- a/inspect4py/cli.py
+++ b/inspect4py/cli.py
@@ -1334,10 +1334,13 @@ def main(input_path, output_dir, ignore_dir_pattern, ignore_file_pattern, requir
         if license_detection:
             try:
                 licenses_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "licenses")
-                rank_list = detect_license(input_path, licenses_path)
-                dir_info["detected_license"] = [{k: f"{v:.1%}"} for k, v in rank_list]
-            except:
-                pass
+                license_text = extract_license(input_path)
+                rank_list = detect_license(license_text, licenses_path)
+                dir_info["license"] = {}
+                dir_info["license"]["detected_type"] = [{k: f"{v:.1%}"} for k, v in rank_list]
+                dir_info["license"]["extracted_text"] = license_text
+            except Exception as e:
+                print("Error when detecting license: %s", str(e))
         if readme:
             dir_info["readme_files"] = extract_readme(input_path)
         if metadata:

--- a/test/test_files/test_license_extraction/LICENSE
+++ b/test/test_files/test_license_extraction/LICENSE
@@ -1,0 +1,1 @@
+A random license.


### PR DESCRIPTION
Augment license detection with the extraction of the license text itself. 

Adds:

License text extraction - the full text of the repository license is now included in dir_info. Can be access with key ["license"]["extracted_text"]
Additional unit test for license extraction

Changes:

Nests extracted text and detected license type under the license key for consistency.
Changes detected license type key in dir_info JSON from ["detected_license"] to ["license"]["detected_type"]
Amends current license detection unit test to use new JSON key structure